### PR TITLE
Add obsidian Git and drawio plugins

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,6 +19,8 @@
   obsidian-minimal-settings =
     pkgs.callPackage ./pkgs/obsidian/minimal-settings {};
   obsidian-dataview = pkgs.callPackage ./pkgs/obsidian/dataview {};
+  obsidian-git = pkgs.callPackage ./pkgs/obsidian/git {};
+  obsidian-drawio = pkgs.callPackage ./pkgs/obsidian/drawio {};
 
   # Neovim plugins
   kulala-nvim = pkgs.callPackage ./pkgs/nvim/kulala {};

--- a/pkgs/obsidian/drawio/default.nix
+++ b/pkgs/obsidian/drawio/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "obsidian-drawio";
+  version = "1.5.4";
+
+  mainJs = fetchurl {
+    url = "https://github.com/zapthedingbat/drawio-obsidian/releases/download/${version}/main.js";
+    sha256 = "sha256-QEANtwb8PrbBZTzQ9uj6DhjHcO1JyL8VK21j5IzF5zo=";
+  };
+
+  manifest = fetchurl {
+    url = "https://github.com/zapthedingbat/drawio-obsidian/releases/download/${version}/manifest.json";
+    sha256 = "sha256-OTpqiJaxAz3QWa2o4yrosnGLki46tTlMkiwBC3TDqyU=";
+  };
+
+  styles = fetchurl {
+    url = "https://github.com/zapthedingbat/drawio-obsidian/releases/download/${version}/styles.css";
+    sha256 = "sha256-krjjIiCJt+PRXdEscZ0TLqgc7XiEo9L/FvclRdTHdxA=";
+  };
+
+  phases = [ "installPhase" ];
+  installPhase = ''
+    mkdir -p $out
+    cp $mainJs $out/main.js
+    cp $manifest $out/manifest.json
+    cp $styles $out/styles.css
+  '';
+
+  meta = with lib; {
+    description = "Integrates draw.io diagrams with Obsidian";
+    homepage = "https://github.com/zapthedingbat/drawio-obsidian";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/obsidian/git/default.nix
+++ b/pkgs/obsidian/git/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "obsidian-git";
+  version = "2.33.0";
+
+  mainJs = fetchurl {
+    url = "https://github.com/Vinzent03/obsidian-git/releases/download/${version}/main.js";
+    sha256 = "sha256-bTgfpbPs5TgQAjVGcGa8kbJJzGz3HqWVf7HVyUh8qOw=";
+  };
+
+  manifest = fetchurl {
+    url = "https://github.com/Vinzent03/obsidian-git/releases/download/${version}/manifest.json";
+    sha256 = "sha256-vn9FG27mlZ7SDjaaCHWJBpkCoab4vW9M2f/L+zfdqE8=";
+  };
+
+  styles = fetchurl {
+    url = "https://github.com/Vinzent03/obsidian-git/releases/download/${version}/styles.css";
+    sha256 = "sha256-n/IoUqqBEqMCRsFtsh7pgQL5EsdWp+sdLbLqHEJvmbY=";
+  };
+
+  phases = [ "installPhase" ];
+  installPhase = ''
+    mkdir -p $out
+    cp $mainJs $out/main.js
+    cp $manifest $out/manifest.json
+    cp $styles $out/styles.css
+  '';
+
+  meta = with lib; {
+    description = "Git integration plugin for Obsidian";
+    homepage = "https://github.com/Vinzent03/obsidian-git";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Summary
- package `obsidian-git` plugin
- package `obsidian-drawio` plugin
- expose the new plugins in `default.nix`

## Testing
- `nix flake check` *(fails: `nix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494438a234832a8fc0b5a91f339908