### PR TITLE
Add kubectl.nvim plugin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -25,4 +25,5 @@
   # Neovim plugins
   kulala-nvim = pkgs.callPackage ./pkgs/nvim/kulala {};
   goose-nvim = pkgs.callPackage ./pkgs/nvim/goose {};
+  kubectl-nvim = pkgs.callPackage ./pkgs/nvim/kubectl {};
 }

--- a/pkgs/nvim/kubectl/default.nix
+++ b/pkgs/nvim/kubectl/default.nix
@@ -1,0 +1,27 @@
+{ lib, vimUtils, fetchFromGitHub }:
+
+vimUtils.buildVimPlugin {
+  pname = "kubectl-nvim";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Ramilito";
+    repo = "kubectl.nvim";
+    rev = "v2.0.0";
+    sha256 = "0qdkdj7p986lf6rycw9f1fkvi2391vpjxibmw21590pbry88d6y1";
+  };
+
+  doCheck = false;
+
+  postInstall = ''
+    rm -rf $out/{.github}
+    rm -f $out/{README.md,LICENSE,Makefile,stylua.toml,vim.toml,.luacheckrc,.luarc.json,.releaserc.json}
+  '';
+
+  meta = with lib; {
+    description = "Interact with Kubernetes clusters from Neovim";
+    homepage = "https://github.com/Ramilito/kubectl.nvim";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Summary
- package kubectl.nvim at version 2.0.0
- expose the package in the default package set

## Testing
- `nix-build -A kubectl-nvim` *(fails: `nix-build` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a84e43a4832ab9bf5d5685cecba3